### PR TITLE
Update requirements to match upstream

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - beautifulsoup4
     - pygments >=2.7
     - python >=3.7
-    - sphinx >= 6.0,<8.0
+    - sphinx >=6.0,<8.0
     - sphinx-basic-ng
 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - 0001-set-node-version-to-18.15.0.patch
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
   script_env:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,17 +23,15 @@ requirements:
   host:
     - flit-core >=2,<4
     - pip
-    - python >=3.6
+    - python >=3.7
     - sphinx-theme-builder
     - nodeenv
     - nodejs ==18.15.0
   run:
     - beautifulsoup4
-    - myst-parser
     - pygments >=2.7
-    - python >=3.6
-    - sphinx >=4
-    - sphinx-inline-tabs
+    - python >=3.7
+    - sphinx >= 6.0,<8.0
     - sphinx-basic-ng
 
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

The new furo has a stricter requirement on the allowed sphinx version. This and the minimum python version are updated to reflect the [upstream requirements](https://github.com/pradyunsg/furo/blob/490527b2aef00b1198770c3389a1979911ee1fcb/pyproject.toml#L17-L23). Moreover, I've removed myst-parser and sphinx-inline-tabs since they are recommended to be used with furo but no strict requirements (see https://github.com/pradyunsg/furo/blob/490527b2aef00b1198770c3389a1979911ee1fcb/docs/recommendations.md?plain=1#L3)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
